### PR TITLE
Add support to bundle contract abis inside js bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,14 @@ Starting the module may look like this:
 
 ## <a name="adding-abis-to-js"> Adding abis into js bundle
 In order to use the option :load-method :use-loaded you need to provide some info at build time so contracts abis
-can be included in the bundle. You provide this information via environment variables at build time.
+can be included in the bundle. You provide this information via :closure-defines in your build like
 
 Example:
 ```
-SMART_CONTRACTS=./src/memefactory/shared/smart_contracts.cljs
-SMART_CONTRACTS_BUILD_PATH=./resources/public/contracts/build/
-SMART_CONTRACTS_SKIP=ds-guard,param-change-registry-db,meme-registry-db,minime-token-factory
+:closure-defines {"goog.DEBUG"                                                   true
+                  "district.ui.smart-contracts.utils.smart-contracts"            "./src/memefactory/shared/smart_contracts.cljs"
+                  "district.ui.smart-contracts.utils.smart-contracts-build-path" "./resources/public/contracts/build/"
+                  "district.ui.smart-contracts.utils.smart-contracts-skip"       "ds-guard,param-change-registry-db,meme-registry-db,minime-token-factory"}
 ```
 
 Be aware that using this method is only supported for contracts compiled in the truffle json format.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ You can pass following args to initiate this module:
 * `:contracts` A map of smart-contracts to load
 * `:load-bin?` Pass true if you want to load BIN files as well
 * `:format` The compiled contracts output format, can be one of :solc-abi-bin :truffle-json
+* `:load-method` How to take contracts content to the browser. Possible values :request(default), :use-loaded (see [adding abis into js bundle](#adding-abis-to-js))
 * `:contracts-path` Path where contracts should be loaded from. Default: `"./contracts/build/"`
 * `:contracts-version` Pass some version for bypassing browser's cache after deploying new contracts to production.
 Pass `:no-cache` if you want to invalidate browser cache on every request (useful for development)
@@ -90,6 +91,19 @@ Starting the module may look like this:
                            :contracts-path "./"}})
     (mount/start))
 ```
+
+## <a name="adding-abis-to-js"> Adding abis into js bundle
+In order to use the option :load-method :use-loaded you need to provide some info at build time so contracts abis
+can be included in the bundle. You provide this information via environment variables at build time.
+
+Example:
+```
+SMART_CONTRACTS=./src/memefactory/shared/smart_contracts.cljs
+SMART_CONTRACTS_BUILD_PATH=./resources/public/contracts/build/
+SMART_CONTRACTS_SKIP=ds-guard,param-change-registry-db,meme-registry-db,minime-token-factory
+```
+
+Be aware that using this method is only supported for contracts compiled in the truffle json format.
 
 ## district.ui.smart-contracts.subs
 re-frame subscriptions provided by this module:

--- a/README.md
+++ b/README.md
@@ -94,14 +94,13 @@ Starting the module may look like this:
 
 ## <a name="adding-abis-to-js"> Adding abis into js bundle
 In order to use the option :load-method :use-loaded you need to provide some info at build time so contracts abis
-can be included in the bundle. You provide this information via :closure-defines in your build like
+can be included in the bundle. You provide this information via environment variables at build time.
 
 Example:
 ```
-:closure-defines {"goog.DEBUG"                                                   true
-                  "district.ui.smart-contracts.utils.smart-contracts"            "./src/memefactory/shared/smart_contracts.cljs"
-                  "district.ui.smart-contracts.utils.smart-contracts-build-path" "./resources/public/contracts/build/"
-                  "district.ui.smart-contracts.utils.smart-contracts-skip"       "ds-guard,param-change-registry-db,meme-registry-db,minime-token-factory"}
+SMART_CONTRACTS=./src/memefactory/shared/smart_contracts.cljs
+SMART_CONTRACTS_BUILD_PATH=./resources/public/contracts/build/
+SMART_CONTRACTS_SKIP=ds-guard,param-change-registry-db,meme-registry-db,minime-token-factory
 ```
 
 Be aware that using this method is only supported for contracts compiled in the truffle json format.

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
                  [day8.re-frame/async-flow-fx "0.0.8"]
                  [day8.re-frame/forward-events-fx "0.0.5"]
                  [day8.re-frame/http-fx "0.1.4"]
+                 [district0x/district-ui-logging "1.0.4"]
                  [district0x.re-frame/web3-fx "1.0.4"]
                  [district0x/district-ui-web3 "1.0.1"]
                  [district0x/re-frame-spec-interceptors "1.0.1"]

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
 
   :dependencies [[cljs-ajax "0.7.2"]
                  [cljs-web3 "0.19.0-0-9"]
+                 [org.clojure/data.json "0.2.6"]
                  [day8.re-frame/async-flow-fx "0.0.8"]
                  [day8.re-frame/forward-events-fx "0.0.5"]
                  [day8.re-frame/http-fx "0.1.4"]

--- a/src/district/ui/smart_contracts/events.cljs
+++ b/src/district/ui/smart_contracts/events.cljs
@@ -10,18 +10,35 @@
     [district.ui.web3.events :as web3-events]
     [district0x.re-frame.spec-interceptors :refer [validate-first-arg validate-args]]
     [re-frame.core :refer [reg-event-fx trim-v]]
-    [clojure.string :as string]))
+    [clojure.string :as string])
+  (:require-macros [district.ui.smart-contracts.utils :refer [slurp-env-contracts]]))
 
 (def interceptors [trim-v])
+(def contracts-files-contents (slurp-env-contracts))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; ATTENTION                                    ;;
+;; Using :load-method :use-loaded only supports ;;
+;; format: truffle-json                         ;;
+;; load-bin?: false                             ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (reg-event-fx
   ::start
   interceptors
-  (fn [{:keys [:db]} [{:keys [:contracts :disable-loading-at-start?] :as opts}]]
+  (fn [{:keys [:db]} [{:keys [:contracts :disable-loading-at-start? :format :load-method :load-bin?]
+                       :or {load-method :request}
+                       :as opts}]]
+    (when (and (= load-method :use-loaded)
+               (or (= load-bin? true)
+                   (not= format :truffle-json)))
+      (throw (js/Error. "Load method :use-loaded only supported for truffle-json. No bin support yet")))
     (merge
       {:db (queries/merge-contracts db contracts)}
       (when-not disable-loading-at-start?
-        {:dispatch [::load-contracts opts]}))))
+        {:dispatch (case load-method
+                     :request [::load-contracts opts]
+                     :use-loaded [::use-loaded-contracts opts])}))))
 
 
 (defn- ensure-slash [path]
@@ -86,6 +103,17 @@
                              (ajax/text-response-format))
           :on-success [::contract-loaded contract-to-load true *load-batch*]
           :on-failure [::contract-loaded contract-to-load false *load-batch*]})})))
+
+(reg-event-fx
+ ::use-loaded-contracts
+ [interceptors (validate-first-arg :district.ui.smart-contracts/opts)]
+ (fn [{:keys [:db]} [{:keys [:contracts] :as opts}]]
+   {:db (reduce
+         (fn [r contract-key]
+           (queries/assoc-contract-abi r contract-key (clj->js (get-in contracts-files-contents [contract-key :abi]))))
+         (queries/merge-contracts db contracts)
+         (keys contracts))
+    :dispatch-n [[::contracts-loaded]]}))
 
 
 (reg-event-fx

--- a/src/district/ui/smart_contracts/utils.clj
+++ b/src/district/ui/smart_contracts/utils.clj
@@ -1,6 +1,11 @@
 (ns district.ui.smart-contracts.utils
   (:require [clojure.string :as str]
-           [clojure.data.json :as json]))
+            [clojure.data.json :as json]
+            [cljs.core]))
+
+(cljs.core/goog-define smart-contracts "")
+(cljs.core/goog-define smart-contracts-build-path "")
+(cljs.core/goog-define smart-contracts-skip "")
 
 (defn get-abi-from-truffle-art [json-path]
   (-> (slurp json-path)
@@ -8,14 +13,14 @@
       :abi))
 
 (defmacro slurp-env-contracts []
-  (let [smart-contracts-file (System/getenv "SMART_CONTRACTS")
-        smart-contracts-build-path (System/getenv "SMART_CONTRACTS_BUILD_PATH")
-        skip-contracts (when-let [scs (System/getenv "SMART_CONTRACTS_SKIP")]
-                         (->> (str/split scs #",")
+  (let [smart-contracts-file smart-contracts
+        smart-contracts-build-path smart-contracts-build-path
+        skip-contracts (when (not-empty smart-contracts-skip)
+                         (->> (str/split smart-contracts-skip #",")
                               (mapv keyword)))]
     (binding [*out* *err*]
       (println "SKIPPING CONTRACTS " skip-contracts)
-      (if (and smart-contracts-file smart-contracts-build-path)
+      (if (and (not-empty smart-contracts-file) (not-empty smart-contracts-build-path))
         (let [[_ _ smart-contracts-map] (->> (slurp smart-contracts-file)
                                              (format "[%s]")
                                              read-string

--- a/src/district/ui/smart_contracts/utils.clj
+++ b/src/district/ui/smart_contracts/utils.clj
@@ -1,11 +1,6 @@
 (ns district.ui.smart-contracts.utils
   (:require [clojure.string :as str]
-            [clojure.data.json :as json]
-            [cljs.core]))
-
-(cljs.core/goog-define smart-contracts "")
-(cljs.core/goog-define smart-contracts-build-path "")
-(cljs.core/goog-define smart-contracts-skip "")
+           [clojure.data.json :as json]))
 
 (defn get-abi-from-truffle-art [json-path]
   (-> (slurp json-path)
@@ -13,14 +8,14 @@
       :abi))
 
 (defmacro slurp-env-contracts []
-  (let [smart-contracts-file smart-contracts
-        smart-contracts-build-path smart-contracts-build-path
-        skip-contracts (when (not-empty smart-contracts-skip)
-                         (->> (str/split smart-contracts-skip #",")
+  (let [smart-contracts-file (System/getenv "SMART_CONTRACTS")
+        smart-contracts-build-path (System/getenv "SMART_CONTRACTS_BUILD_PATH")
+        skip-contracts (when-let [scs (System/getenv "SMART_CONTRACTS_SKIP")]
+                         (->> (str/split scs #",")
                               (mapv keyword)))]
     (binding [*out* *err*]
       (println "SKIPPING CONTRACTS " skip-contracts)
-      (if (and (not-empty smart-contracts-file) (not-empty smart-contracts-build-path))
+      (if (and smart-contracts-file smart-contracts-build-path)
         (let [[_ _ smart-contracts-map] (->> (slurp smart-contracts-file)
                                              (format "[%s]")
                                              read-string

--- a/src/district/ui/smart_contracts/utils.clj
+++ b/src/district/ui/smart_contracts/utils.clj
@@ -1,0 +1,34 @@
+(ns district.ui.smart-contracts.utils
+  (:require [clojure.string :as str]
+           [clojure.data.json :as json]))
+
+(defn get-abi-from-truffle-art [json-path]
+  (-> (slurp json-path)
+      (json/read-str :key-fn keyword)
+      :abi))
+
+(defmacro slurp-env-contracts []
+  (let [smart-contracts-file (System/getenv "SMART_CONTRACTS")
+        smart-contracts-build-path (System/getenv "SMART_CONTRACTS_BUILD_PATH")
+        skip-contracts (when-let [scs (System/getenv "SMART_CONTRACTS_SKIP")]
+                         (->> (str/split scs #",")
+                              (mapv keyword)))]
+    (binding [*out* *err*]
+      (println "SKIPPING CONTRACTS " skip-contracts)
+      (if (and smart-contracts-file smart-contracts-build-path)
+        (let [[_ _ smart-contracts-map] (->> (slurp smart-contracts-file)
+                                             (format "[%s]")
+                                             read-string
+                                             second)
+              contracts-to-load (apply dissoc smart-contracts-map skip-contracts)]
+          (println "ADDING CONTRACTS ABIS INTO BUILD : " (keys contracts-to-load))
+          (->> contracts-to-load
+               (map (fn [[contract-key {:keys [name]}]]
+                      [contract-key {:abi (get-abi-from-truffle-art (str smart-contracts-build-path
+                                                                         "/"
+                                                                         name
+                                                                         ".json"))}]))
+               (into {})))
+
+        (do (println "WARNING: Please set SMART_CONTRACTS and SMART_CONTRACTS_FORMAT environment variables if you want to inject abis into bundle")
+            {})))))


### PR DESCRIPTION
Old behavior should still work with `:load-method` `:request` which happens to be the default.
This method uses macro expansion time to grab abis from compiled files and inject them in the code so they end up compiled in the bundle.
Haven't figure out yet how to do it without using env vars to configure the process